### PR TITLE
Remove master from genpodoptions.

### DIFF
--- a/cmd/genpod/app/options/options.go
+++ b/cmd/genpod/app/options/options.go
@@ -21,7 +21,6 @@ import (
 )
 
 type GenPodOptions struct {
-	Master     string
 	Kubeconfig string
 	Verbose    bool
 	Namespace  string

--- a/cmd/genpod/app/server.go
+++ b/cmd/genpod/app/server.go
@@ -71,12 +71,11 @@ func Validate(opt *options.GenPodOptions) error {
 }
 
 func Run(opt *options.GenPodOptions) error {
-	var err error
-	opt.Master, err = utils.GetMasterFromKubeConfig(opt.Kubeconfig)
+	master, err := utils.GetMasterFromKubeConfig(opt.Kubeconfig)
 	if err != nil {
 		return fmt.Errorf("Failed to parse kubeconfig file: %v ", err)
 	}
-	client, err := getKubeClient(opt.Master, opt.Kubeconfig)
+	client, err := getKubeClient(master, opt.Kubeconfig)
 	if err != nil {
 		return err
 	}


### PR DESCRIPTION
As master is directly read from kubeconfig, there is no need to keep master field as part of genpodoptions.