### PR TITLE
Simulator should not log errors when there is no fit

### DIFF
--- a/pkg/framework/report.go
+++ b/pkg/framework/report.go
@@ -267,7 +267,7 @@ func clusterCapacityReviewPrettyPrint(r *ClusterCapacityReview, verbose bool) {
 		if verbose {
 			fmt.Printf("The cluster can schedule %v instance(s) of the pod %v.\n", instancesSum(pod.ReplicasOnNodes), pod.PodName)
 		} else {
-			fmt.Printf("\n%v\n", instancesSum(pod.ReplicasOnNodes))
+			fmt.Printf("%v\n", instancesSum(pod.ReplicasOnNodes))
 		}
 	}
 


### PR DESCRIPTION
This gets rid of the extraneous logging of the error when a fit is no longer possible.