### PR TITLE
cluster-capacity should only list resources needed by scheduler

### DIFF
--- a/pkg/api/api.go
+++ b/pkg/api/api.go
@@ -34,11 +34,6 @@ const (
 	Services               ResourceType = "services"
 	PersistentVolumeClaims ResourceType = "persistentvolumeclaims"
 	ReplicaSets            ResourceType = "replicasets"
-	ResourceQuota          ResourceType = "resourcequotas"
-	Secrets                ResourceType = "secrets"
-	ServiceAccounts        ResourceType = "serviceaccounts"
-	LimitRanges            ResourceType = "limitranges"
-	Namespaces             ResourceType = "namespaces"
 )
 
 func (r ResourceType) String() string {
@@ -61,16 +56,6 @@ func (r ResourceType) ObjectType() runtime.Object {
 		return &v1.PersistentVolumeClaim{}
 	case "replicasets":
 		return &v1beta1.ReplicaSet{}
-	case "resourcequotas":
-		return &v1.ResourceQuota{}
-	case "secrets":
-		return &v1.Secret{}
-	case "serviceaccounts":
-		return &v1.ServiceAccount{}
-	case "limitranges":
-		return &v1.LimitRange{}
-	case "namespaces":
-		return &v1.Namespace{}
 	}
 	return nil
 }
@@ -91,16 +76,6 @@ func StringToResourceType(resource string) (ResourceType, error) {
 		return PersistentVolumeClaims, nil
 	case "replicasets":
 		return ReplicaSets, nil
-	case "resourcequotas":
-		return ResourceQuota, nil
-	case "secrets":
-		return Secrets, nil
-	case "serviceaccounts":
-		return ServiceAccounts, nil
-	case "limitranges":
-		return LimitRanges, nil
-	case "namespaces":
-		return Namespaces, nil
 	default:
 		return "", fmt.Errorf("Resource type %v not recognized", resource)
 	}

--- a/pkg/framework/restclient/external/restclient.go
+++ b/pkg/framework/restclient/external/restclient.go
@@ -234,96 +234,6 @@ func (c *RESTClient) ReplicaSets(fieldsSelector fields.Selector) *v1beta1.Replic
 	}
 }
 
-func (c *RESTClient) ResourceQuota(fieldsSelector fields.Selector) *v1.ResourceQuotaList {
-	items := c.resourceStore.List(ccapi.ResourceQuota)
-	typedItems := make([]v1.ResourceQuota, 0, len(items))
-	for _, item := range items {
-		if !fieldsSelector.Matches(NewObjectFieldsAccessor(item)) {
-			continue
-		}
-		typedItems = append(typedItems, *item.(*v1.ResourceQuota))
-	}
-
-	return &v1.ResourceQuotaList{
-		ListMeta: metav1.ListMeta{
-			ResourceVersion: "0",
-		},
-		Items: typedItems,
-	}
-}
-
-func (c *RESTClient) Secrets(fieldsSelector fields.Selector) *v1.SecretList {
-	items := c.resourceStore.List(ccapi.Secrets)
-	typedItems := make([]v1.Secret, 0, len(items))
-	for _, item := range items {
-		if !fieldsSelector.Matches(NewObjectFieldsAccessor(item)) {
-			continue
-		}
-		typedItems = append(typedItems, *item.(*v1.Secret))
-	}
-
-	return &v1.SecretList{
-		ListMeta: metav1.ListMeta{
-			ResourceVersion: "0",
-		},
-		Items: typedItems,
-	}
-}
-
-func (c *RESTClient) ServiceAccounts(fieldsSelector fields.Selector) *v1.ServiceAccountList {
-	items := c.resourceStore.List(ccapi.ServiceAccounts)
-	typedItems := make([]v1.ServiceAccount, 0, len(items))
-	for _, item := range items {
-		if !fieldsSelector.Matches(NewObjectFieldsAccessor(item)) {
-			continue
-		}
-		typedItems = append(typedItems, *item.(*v1.ServiceAccount))
-	}
-
-	return &v1.ServiceAccountList{
-		ListMeta: metav1.ListMeta{
-			ResourceVersion: "0",
-		},
-		Items: typedItems,
-	}
-}
-
-func (c *RESTClient) LimitRanges(fieldsSelector fields.Selector) *v1.LimitRangeList {
-	items := c.resourceStore.List(ccapi.LimitRanges)
-	typedItems := make([]v1.LimitRange, 0, len(items))
-	for _, item := range items {
-		if !fieldsSelector.Matches(NewObjectFieldsAccessor(item)) {
-			continue
-		}
-		typedItems = append(typedItems, *item.(*v1.LimitRange))
-	}
-
-	return &v1.LimitRangeList{
-		ListMeta: metav1.ListMeta{
-			ResourceVersion: "0",
-		},
-		Items: typedItems,
-	}
-}
-
-func (c *RESTClient) Namespaces(fieldsSelector fields.Selector) *v1.NamespaceList {
-	items := c.resourceStore.List(ccapi.Namespaces)
-	typedItems := make([]v1.Namespace, 0, len(items))
-	for _, item := range items {
-		if !fieldsSelector.Matches(NewObjectFieldsAccessor(item)) {
-			continue
-		}
-		typedItems = append(typedItems, *item.(*v1.Namespace))
-	}
-
-	return &v1.NamespaceList{
-		ListMeta: metav1.ListMeta{
-			ResourceVersion: "0",
-		},
-		Items: typedItems,
-	}
-}
-
 func (c *RESTClient) List(resource ccapi.ResourceType, fieldsSelector fields.Selector) (runtime.Object, error) {
 	switch resource {
 	case ccapi.Pods:
@@ -340,16 +250,6 @@ func (c *RESTClient) List(resource ccapi.ResourceType, fieldsSelector fields.Sel
 		return c.Nodes(fieldsSelector), nil
 	case ccapi.ReplicaSets:
 		return c.ReplicaSets(fieldsSelector), nil
-	case ccapi.ResourceQuota:
-		return c.ResourceQuota(fieldsSelector), nil
-	case ccapi.Secrets:
-		return c.Secrets(fieldsSelector), nil
-	case ccapi.ServiceAccounts:
-		return c.ServiceAccounts(fieldsSelector), nil
-	case ccapi.LimitRanges:
-		return c.LimitRanges(fieldsSelector), nil
-	case ccapi.Namespaces:
-		return c.Namespaces(fieldsSelector), nil
 	default:
 		return nil, fmt.Errorf("Resource %s not recognized", resource)
 	}
@@ -521,20 +421,6 @@ func (c *RESTClient) createGetReadCloser(resource ccapi.ResourceType, resourceNa
 	case ccapi.ReplicaSets:
 		obj = runtime.Object(item.(*v1beta1.ReplicaSet))
 		ns = item.(*v1beta1.ReplicaSet).Namespace
-	case ccapi.ResourceQuota:
-		obj = runtime.Object(item.(*v1.ResourceQuota))
-		ns = item.(*v1.ResourceQuota).Namespace
-	case ccapi.Secrets:
-		obj = runtime.Object(item.(*v1.Secret))
-		ns = item.(*v1.Secret).Namespace
-	case ccapi.ServiceAccounts:
-		obj = runtime.Object(item.(*v1.ServiceAccount))
-		ns = item.(*v1.ServiceAccount).Namespace
-	case ccapi.LimitRanges:
-		obj = runtime.Object(item.(*v1.LimitRange))
-		ns = item.(*v1.LimitRange).Namespace
-	case ccapi.Namespaces:
-		obj = runtime.Object(item.(*v1.Namespace))
 	default:
 		return nil, fmt.Errorf("Resource %v not recognized", resource)
 	}
@@ -595,26 +481,6 @@ func (c *RESTClient) createWatchReadCloser(resource ccapi.ResourceType, fieldsSe
 		}
 	case ccapi.ReplicaSets:
 		for _, item := range c.ReplicaSets(fieldsSelector).Items {
-			rg.EmitWatchEvent(watch.Added, runtime.Object(&item))
-		}
-	case ccapi.ResourceQuota:
-		for _, item := range c.ResourceQuota(fieldsSelector).Items {
-			rg.EmitWatchEvent(watch.Added, runtime.Object(&item))
-		}
-	case ccapi.Secrets:
-		for _, item := range c.Secrets(fieldsSelector).Items {
-			rg.EmitWatchEvent(watch.Added, runtime.Object(&item))
-		}
-	case ccapi.ServiceAccounts:
-		for _, item := range c.ServiceAccounts(fieldsSelector).Items {
-			rg.EmitWatchEvent(watch.Added, runtime.Object(&item))
-		}
-	case ccapi.LimitRanges:
-		for _, item := range c.LimitRanges(fieldsSelector).Items {
-			rg.EmitWatchEvent(watch.Added, runtime.Object(&item))
-		}
-	case ccapi.Namespaces:
-		for _, item := range c.Namespaces(fieldsSelector).Items {
 			rg.EmitWatchEvent(watch.Added, runtime.Object(&item))
 		}
 	default:
@@ -722,25 +588,6 @@ func (c *RESTClient) Do(req *http.Request) (*http.Response, error) {
 				if !strings.EqualFold(parts[4], "status") {
 					return nil, fmt.Errorf("Cluster capacity RESTClient not implemented: query url does not end with status: %v", req.URL.Path)
 				}
-
-				if parts[2] != "resourcequotas" {
-					return nil, fmt.Errorf("Cluster capacity RESTClient not implemented: status can be queried only for resourcequotas: %v", req.URL.Path)
-				}
-
-				// decode and update resource quota in the local cache
-				var buffer bytes.Buffer
-				buff := make([]byte, 100, 100)
-				for {
-					n, err := req.Body.Read(buff)
-					buffer.WriteString(string(buff[:n]))
-					if err != nil {
-						break
-					}
-				}
-
-				obj := &v1.ResourceQuota{}
-				runtime.DecodeInto(api.Codecs.UniversalDecoder(), buffer.Bytes(), runtime.Object(obj))
-				c.resourceStore.Add(ccapi.ResourceQuota, obj)
 			}
 
 			if parts[0] != "namespaces" {

--- a/pkg/framework/simulator.go
+++ b/pkg/framework/simulator.go
@@ -20,7 +20,6 @@ import (
 	"fmt"
 	"io/ioutil"
 	"os"
-	"strings"
 	"sync"
 	"time"
 
@@ -192,11 +191,6 @@ func (c *ClusterCapacity) Bind(binding *v1.Binding, schedulerName string) error 
 
 	// all good, create another pod
 	if err := c.nextPod(); err != nil {
-		if strings.HasPrefix(c.status.StopReason, "NamespaceNotFound") {
-			c.Close()
-			c.stop <- struct{}{}
-			return nil
-		}
 		return fmt.Errorf("Unable to create next pod to schedule: %v", err)
 	}
 	return nil
@@ -245,13 +239,6 @@ func (c *ClusterCapacity) nextPod() error {
 	pod.Spec.NodeName = ""
 	// use simulated pod name with an index to construct the name
 	pod.ObjectMeta.Name = fmt.Sprintf("%v-%v", c.simulatedPod.Name, c.simulated)
-
-	// Check the pod's namespace exists
-	_, err := c.externalkubeclient.Core().Namespaces().Get(pod.ObjectMeta.Namespace, metav1.GetOptions{})
-	if err != nil {
-		c.status.StopReason = fmt.Sprintf("NamespaceNotFound: %v", err)
-		return fmt.Errorf("Pod's namespace %v not found: %v", c.simulatedPod.ObjectMeta.Namespace, err)
-	}
 
 	c.simulated++
 	c.lastSimulatedPod = &pod

--- a/pkg/framework/simulator.go
+++ b/pkg/framework/simulator.go
@@ -295,7 +295,7 @@ func (c *ClusterCapacity) createSchedulerConfig(s *soptions.SchedulerServer) (*s
 		c.informerFactory.Core().V1().PersistentVolumes(),
 		c.informerFactory.Core().V1().PersistentVolumeClaims(),
 		c.informerFactory.Core().V1().ReplicationControllers(),
-		c.informerFactory.Extensions().V1beta1().ReplicaSets(),
+		fakeInformerFactory.Extensions().V1beta1().ReplicaSets(),
 		fakeInformerFactory.Apps().V1beta1().StatefulSets(),
 		c.informerFactory.Core().V1().Services(),
 		s.HardPodAffinitySymmetricWeight)

--- a/pkg/framework/simulator_test.go
+++ b/pkg/framework/simulator_test.go
@@ -164,11 +164,6 @@ func TestPrediction(t *testing.T) {
 		t.Errorf("Unexpected error: %v", err)
 	}
 
-	namespace := &v1.Namespace{ObjectMeta: metav1.ObjectMeta{Name: "test-node-3"}}
-	if err := resourceStore.Add("namespaces", metav1.Object(namespace)); err != nil {
-		t.Errorf("Unexpected error: %v", err)
-	}
-
 	simulatedPod := &v1.Pod{
 		ObjectMeta: metav1.ObjectMeta{Name: "simulated-pod", Namespace: "test-node-3", ResourceVersion: "10"},
 		Spec:       apitesting.V1DeepEqualSafePodSpec(),

--- a/pkg/framework/store/store.go
+++ b/pkg/framework/store/store.go
@@ -43,8 +43,6 @@ type ResourceStore interface {
 	Resources() []ccapi.ResourceType
 }
 
-// TODO(jchaloup,hodovska): currently, only scheduler caches are considered.
-// Later, include cache for each object.
 type resourceStore struct {
 	// Caches modifed by emulation strategy
 	PodCache                   cache.Store
@@ -54,11 +52,6 @@ type resourceStore struct {
 	ServiceCache               cache.Store
 	ReplicationControllerCache cache.Store
 	ReplicaSetCache            cache.Store
-	ResourceQuotaCache         cache.Store
-	SecretCache                cache.Store
-	ServiceAccountCache        cache.Store
-	LimitRangeCache            cache.Store
-	NamespaceCache             cache.Store
 
 	resourceToCache map[ccapi.ResourceType]cache.Store
 	eventHandler    map[ccapi.ResourceType]cache.ResourceEventHandler
@@ -193,11 +186,6 @@ func NewResourceStore() *resourceStore {
 		ServiceCache:               cache.NewStore(cache.MetaNamespaceKeyFunc),
 		ReplicaSetCache:            cache.NewStore(cache.MetaNamespaceKeyFunc),
 		ReplicationControllerCache: cache.NewStore(cache.MetaNamespaceKeyFunc),
-		ResourceQuotaCache:         cache.NewStore(cache.MetaNamespaceKeyFunc),
-		SecretCache:                cache.NewStore(cache.MetaNamespaceKeyFunc),
-		ServiceAccountCache:        cache.NewStore(cache.MetaNamespaceKeyFunc),
-		LimitRangeCache:            cache.NewStore(cache.MetaNamespaceKeyFunc),
-		NamespaceCache:             cache.NewStore(cache.MetaNamespaceKeyFunc),
 		eventHandler:               make(map[ccapi.ResourceType]cache.ResourceEventHandler),
 	}
 
@@ -209,11 +197,6 @@ func NewResourceStore() *resourceStore {
 		ccapi.Services:               resourceStore.ServiceCache,
 		ccapi.ReplicaSets:            resourceStore.ReplicaSetCache,
 		ccapi.ReplicationControllers: resourceStore.ReplicationControllerCache,
-		ccapi.ResourceQuota:          resourceStore.ResourceQuotaCache,
-		ccapi.Secrets:                resourceStore.SecretCache,
-		ccapi.ServiceAccounts:        resourceStore.ServiceAccountCache,
-		ccapi.LimitRanges:            resourceStore.LimitRangeCache,
-		ccapi.Namespaces:             resourceStore.NamespaceCache,
 	}
 
 	resourceStore.resourceToCache = resourceToCache


### PR DESCRIPTION
the cluster-capacity command should work with same RBAC privileges as scheduler - bind.

remove resources not needed by the scheduler framework from being pulled.