### PR TITLE
Remove resources that are not needed to run cluster capacity analysis.

### DIFF
--- a/pkg/api/api.go
+++ b/pkg/api/api.go
@@ -21,7 +21,6 @@ import (
 
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/kubernetes/pkg/api/v1"
-	"k8s.io/kubernetes/pkg/apis/extensions/v1beta1"
 )
 
 type ResourceType string
@@ -29,11 +28,9 @@ type ResourceType string
 const (
 	Pods                   ResourceType = "pods"
 	PersistentVolumes      ResourceType = "persistentvolumes"
-	ReplicationControllers ResourceType = "replicationcontrollers"
 	Nodes                  ResourceType = "nodes"
 	Services               ResourceType = "services"
 	PersistentVolumeClaims ResourceType = "persistentvolumeclaims"
-	ReplicaSets            ResourceType = "replicasets"
 )
 
 func (r ResourceType) String() string {
@@ -46,16 +43,12 @@ func (r ResourceType) ObjectType() runtime.Object {
 		return &v1.Pod{}
 	case "persistentvolumes":
 		return &v1.PersistentVolume{}
-	case "replicationcontrollers":
-		return &v1.ReplicationController{}
 	case "nodes":
 		return &v1.Node{}
 	case "services":
 		return &v1.Service{}
 	case "persistentvolumeclaims":
 		return &v1.PersistentVolumeClaim{}
-	case "replicasets":
-		return &v1beta1.ReplicaSet{}
 	}
 	return nil
 }
@@ -66,16 +59,12 @@ func StringToResourceType(resource string) (ResourceType, error) {
 		return Pods, nil
 	case "persistentvolumes":
 		return PersistentVolumes, nil
-	case "replicationcontrollers":
-		return ReplicationControllers, nil
 	case "nodes":
 		return Nodes, nil
 	case "services":
 		return Services, nil
 	case "persistentvolumeclaims":
 		return PersistentVolumeClaims, nil
-	case "replicasets":
-		return ReplicaSets, nil
 	default:
 		return "", fmt.Errorf("Resource type %v not recognized", resource)
 	}

--- a/pkg/client/nspod.go
+++ b/pkg/client/nspod.go
@@ -41,7 +41,7 @@ func RetrieveNamespacePod(client clientset.Interface, namespace string) (*v1.Pod
 		},
 		Spec: v1.PodSpec{
 			Containers: []v1.Container{
-				v1.Container{
+				{
 					Name:            "cluster-capacity-stub-container",
 					Image:           "gcr.io/google_containers/pause:2.0",
 					ImagePullPolicy: v1.PullAlways,

--- a/pkg/framework/restclient/external/watch_test.go
+++ b/pkg/framework/restclient/external/watch_test.go
@@ -60,8 +60,6 @@ func emitEvent(client *RESTClient, resource ccapi.ResourceType, test eventTest) 
 		client.EmitObjectWatchEvent(resource, test.event, test.item.(*v1.Pod))
 	case ccapi.Services:
 		client.EmitObjectWatchEvent(resource, test.event, test.item.(*v1.Service))
-	case ccapi.ReplicationControllers:
-		client.EmitObjectWatchEvent(resource, test.event, test.item.(*v1.ReplicationController))
 	case ccapi.PersistentVolumes:
 		client.EmitObjectWatchEvent(resource, test.event, test.item.(*v1.PersistentVolume))
 	case ccapi.Nodes:
@@ -174,32 +172,6 @@ func TestWatchServices(t *testing.T) {
 	}
 
 	testWatch(tests, ccapi.Services, t)
-}
-
-func TestWatchReplicationControllers(t *testing.T) {
-
-	rc := test.ReplicationControllerExample("rc1")
-
-	tests := []eventTest{
-		{
-			event: watch.Modified,
-			item:  &rc,
-		},
-		{
-			event: watch.Added,
-			item:  &rc,
-		},
-		{
-			event: watch.Modified,
-			item:  &rc,
-		},
-		{
-			event: watch.Deleted,
-			item:  &rc,
-		},
-	}
-
-	testWatch(tests, ccapi.ReplicationControllers, t)
 }
 
 func TestWatchPersistentVolumes(t *testing.T) {

--- a/pkg/framework/simulator.go
+++ b/pkg/framework/simulator.go
@@ -110,12 +110,7 @@ func (c *ClusterCapacity) Report() *ClusterCapacityReview {
 
 func (c *ClusterCapacity) SyncWithClient(client externalclientset.Interface) error {
 	for _, resource := range c.resourceStore.Resources() {
-		var listWatcher *cache.ListWatch
-		if resource == ccapi.ReplicaSets {
-			listWatcher = cache.NewListWatchFromClient(client.Extensions().RESTClient(), resource.String(), metav1.NamespaceAll, fields.ParseSelectorOrDie(""))
-		} else {
-			listWatcher = cache.NewListWatchFromClient(client.Core().RESTClient(), resource.String(), metav1.NamespaceAll, fields.ParseSelectorOrDie(""))
-		}
+		listWatcher := cache.NewListWatchFromClient(client.Core().RESTClient(), resource.String(), metav1.NamespaceAll, fields.ParseSelectorOrDie(""))
 
 		options := metav1.ListOptions{ResourceVersion: "0"}
 		list, err := listWatcher.List(options)
@@ -294,7 +289,7 @@ func (c *ClusterCapacity) createSchedulerConfig(s *soptions.SchedulerServer) (*s
 		c.informerFactory.Core().V1().Nodes(),
 		c.informerFactory.Core().V1().PersistentVolumes(),
 		c.informerFactory.Core().V1().PersistentVolumeClaims(),
-		c.informerFactory.Core().V1().ReplicationControllers(),
+		fakeInformerFactory.Core().V1().ReplicationControllers(),
 		fakeInformerFactory.Extensions().V1beta1().ReplicaSets(),
 		fakeInformerFactory.Apps().V1beta1().StatefulSets(),
 		c.informerFactory.Core().V1().Services(),

--- a/pkg/framework/store/fake.go
+++ b/pkg/framework/store/fake.go
@@ -23,7 +23,6 @@ import (
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/client-go/tools/cache"
 	"k8s.io/kubernetes/pkg/api/v1"
-	"k8s.io/kubernetes/pkg/apis/extensions/v1beta1"
 
 	ccapi "github.com/kubernetes-incubator/cluster-capacity/pkg/api"
 )
@@ -31,11 +30,9 @@ import (
 type FakeResourceStore struct {
 	PodsData                   func() []*v1.Pod
 	ServicesData               func() []*v1.Service
-	ReplicationControllersData func() []*v1.ReplicationController
 	NodesData                  func() []*v1.Node
 	PersistentVolumesData      func() []*v1.PersistentVolume
 	PersistentVolumeClaimsData func() []*v1.PersistentVolumeClaim
-	ReplicaSetsData            func() []*v1beta1.ReplicaSet
 	// TODO(jchaloup): fill missing resource functions
 }
 
@@ -79,9 +76,6 @@ func findResource(obj interface{}, objs interface{}) (item interface{}, exists b
 		case v1.Service:
 			value := item.(v1.Service)
 			obj_key, key_err = cache.MetaNamespaceKeyFunc(metav1.Object(&value))
-		case v1.ReplicationController:
-			value := item.(v1.ReplicationController)
-			obj_key, key_err = cache.MetaNamespaceKeyFunc(metav1.Object(&value))
 		case v1.Node:
 			value := item.(v1.Node)
 			obj_key, key_err = cache.MetaNamespaceKeyFunc(metav1.Object(&value))
@@ -114,11 +108,6 @@ func (s *FakeResourceStore) List(resource ccapi.ResourceType) []interface{} {
 			return make([]interface{}, 0, 0)
 		}
 		return resourcesToItems(s.ServicesData())
-	case ccapi.ReplicationControllers:
-		if s.ReplicationControllersData == nil {
-			return make([]interface{}, 0, 0)
-		}
-		return resourcesToItems(s.ReplicationControllersData())
 	case ccapi.Nodes:
 		if s.NodesData == nil {
 			return make([]interface{}, 0, 0)
@@ -134,11 +123,6 @@ func (s *FakeResourceStore) List(resource ccapi.ResourceType) []interface{} {
 			return make([]interface{}, 0, 0)
 		}
 		return resourcesToItems(s.PersistentVolumeClaimsData())
-	case ccapi.ReplicaSets:
-		if s.ReplicaSetsData == nil {
-			return make([]interface{}, 0, 0)
-		}
-		return resourcesToItems(s.ReplicaSetsData())
 	}
 	return make([]interface{}, 0, 0)
 }
@@ -149,16 +133,12 @@ func (s *FakeResourceStore) Get(resource ccapi.ResourceType, obj interface{}) (i
 		return findResource(obj, s.PodsData())
 	case ccapi.Services:
 		return findResource(obj, s.ServicesData())
-	case ccapi.ReplicationControllers:
-		return findResource(obj, s.ReplicationControllersData())
 	case ccapi.Nodes:
 		return findResource(obj, s.NodesData())
 	case ccapi.PersistentVolumes:
 		return findResource(obj, s.PersistentVolumesData())
 	case ccapi.PersistentVolumeClaims:
 		return findResource(obj, s.PersistentVolumeClaimsData())
-		//case "replicasets":
-		//	return testReplicaSetsData().Items
 	}
 	return nil, false, nil
 }
@@ -176,5 +156,5 @@ func (s *FakeResourceStore) Replace(resource ccapi.ResourceType, items []interfa
 }
 
 func (s *FakeResourceStore) Resources() []ccapi.ResourceType {
-	return []ccapi.ResourceType{ccapi.Pods, ccapi.Services, ccapi.ReplicationControllers, ccapi.Nodes, ccapi.PersistentVolumes, ccapi.PersistentVolumeClaims}
+	return []ccapi.ResourceType{ccapi.Pods, ccapi.Services, ccapi.Nodes, ccapi.PersistentVolumes, ccapi.PersistentVolumeClaims}
 }

--- a/pkg/framework/store/store.go
+++ b/pkg/framework/store/store.go
@@ -45,13 +45,11 @@ type ResourceStore interface {
 
 type resourceStore struct {
 	// Caches modifed by emulation strategy
-	PodCache                   cache.Store
-	NodeCache                  cache.Store
-	PVCCache                   cache.Store
-	PVCache                    cache.Store
-	ServiceCache               cache.Store
-	ReplicationControllerCache cache.Store
-	ReplicaSetCache            cache.Store
+	PodCache     cache.Store
+	NodeCache    cache.Store
+	PVCCache     cache.Store
+	PVCache      cache.Store
+	ServiceCache cache.Store
 
 	resourceToCache map[ccapi.ResourceType]cache.Store
 	eventHandler    map[ccapi.ResourceType]cache.ResourceEventHandler
@@ -179,14 +177,12 @@ func (s *resourceStore) Resources() []ccapi.ResourceType {
 func NewResourceStore() *resourceStore {
 
 	resourceStore := &resourceStore{
-		PodCache:                   cache.NewStore(cache.MetaNamespaceKeyFunc),
-		NodeCache:                  cache.NewStore(cache.MetaNamespaceKeyFunc),
-		PVCache:                    cache.NewStore(cache.MetaNamespaceKeyFunc),
-		PVCCache:                   cache.NewStore(cache.MetaNamespaceKeyFunc),
-		ServiceCache:               cache.NewStore(cache.MetaNamespaceKeyFunc),
-		ReplicaSetCache:            cache.NewStore(cache.MetaNamespaceKeyFunc),
-		ReplicationControllerCache: cache.NewStore(cache.MetaNamespaceKeyFunc),
-		eventHandler:               make(map[ccapi.ResourceType]cache.ResourceEventHandler),
+		PodCache:     cache.NewStore(cache.MetaNamespaceKeyFunc),
+		NodeCache:    cache.NewStore(cache.MetaNamespaceKeyFunc),
+		PVCache:      cache.NewStore(cache.MetaNamespaceKeyFunc),
+		PVCCache:     cache.NewStore(cache.MetaNamespaceKeyFunc),
+		ServiceCache: cache.NewStore(cache.MetaNamespaceKeyFunc),
+		eventHandler: make(map[ccapi.ResourceType]cache.ResourceEventHandler),
 	}
 
 	resourceToCache := map[ccapi.ResourceType]cache.Store{
@@ -195,8 +191,6 @@ func NewResourceStore() *resourceStore {
 		ccapi.Nodes:                  resourceStore.NodeCache,
 		ccapi.PersistentVolumes:      resourceStore.PVCache,
 		ccapi.Services:               resourceStore.ServiceCache,
-		ccapi.ReplicaSets:            resourceStore.ReplicaSetCache,
-		ccapi.ReplicationControllers: resourceStore.ReplicationControllerCache,
 	}
 
 	resourceStore.resourceToCache = resourceToCache
@@ -207,12 +201,7 @@ func NewResourceStore() *resourceStore {
 func NewResourceReflectors(client clientset.Interface, stopCh <-chan struct{}) *resourceStore {
 	rs := NewResourceStore()
 	for _, resource := range rs.Resources() {
-		var listWatcher *cache.ListWatch
-		if resource == ccapi.ReplicaSets {
-			listWatcher = cache.NewListWatchFromClient(client.Extensions().RESTClient(), resource.String(), metav1.NamespaceAll, fields.ParseSelectorOrDie(""))
-		} else {
-			listWatcher = cache.NewListWatchFromClient(client.Core().RESTClient(), resource.String(), metav1.NamespaceAll, fields.ParseSelectorOrDie(""))
-		}
+		listWatcher := cache.NewListWatchFromClient(client.Core().RESTClient(), resource.String(), metav1.NamespaceAll, fields.ParseSelectorOrDie(""))
 		cache.NewReflector(listWatcher, resource.ObjectType(), rs.resourceToCache[resource], 0).RunUntil(stopCh)
 	}
 	return rs

--- a/pkg/framework/watch/watch.go
+++ b/pkg/framework/watch/watch.go
@@ -25,7 +25,6 @@ import (
 	"time"
 
 	"k8s.io/apimachinery/pkg/runtime"
-	"k8s.io/apimachinery/pkg/runtime/schema"
 	"k8s.io/apimachinery/pkg/watch"
 	"k8s.io/kubernetes/pkg/api"
 	"k8s.io/kubernetes/pkg/api/v1"
@@ -101,10 +100,6 @@ func (c *WatchBuffer) EmitWatchEvent(eType watch.EventType, object runtime.Objec
 	}
 
 	gv := v1.SchemeGroupVersion
-	if c.Resource == ccapi.ReplicaSets {
-		gv = schema.GroupVersion{Group: "extensions", Version: "v1beta1"}
-	}
-
 	encoder := api.Codecs.EncoderForVersion(info.Serializer, gv)
 
 	obj_str := runtime.EncodeOrDie(encoder, object)


### PR DESCRIPTION
@derekwaynecarr 

I have reduced resource further to only pods and nodes. With this and RBAC, the only role that is needed to run cluster capacity is:

```
kind: ClusterRole
apiVersion: v1
metadata:
  name: cc-role
rules:
- apiGroups: [""]
  resources: ["pods", "nodes",  "persistentvolumeclaims", "persistentvolumes", "services"]
  verbs: ["get", "watch", "list"]
```
