### PR TITLE
Make functions in integration-test.sh script POSIX compliant.

### DIFF
--- a/integration-tests.sh
+++ b/integration-tests.sh
@@ -27,11 +27,11 @@ RED='\033[0;31m'
 GREEN='\033[0;32m'
 NC='\033[0m'
 
-function printError {
+printError() {
   echo -e "${RED}$1${NC}"
 }
 
-function printSuccess {
+printSuccess() {
   echo -e "${GREEN}$1${NC}"
 }
 


### PR DESCRIPTION
Remove BASH function definition syntax in integration-tests.sh to be able to run it in a system with a different default shell (e.g. ubuntu).