### PR TITLE
travis ci should use go 1.8

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,6 @@
 language: go
 go:
-- 1.7
+- 1.8
 script:
 - make build
 - make test


### PR DESCRIPTION
Travis CI is configured for Go 1.7.  It needs to use 1.8.