### PR TITLE
Set cluster capacity's scheduler instance's name to cluster-capacity to avoid  conflict with default-scheduler. 

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -26,7 +26,7 @@ integration-tests:
 	./integration-tests.sh
 
 image:
-	docker build -t docker.io/gofed/cluster-capacity .
+	docker build -t cluster-capacity .
 
 clean:
 	rm -f cluster-capacity genpod hypercc

--- a/cmd/cluster-capacity/app/options/options.go
+++ b/cmd/cluster-capacity/app/options/options.go
@@ -95,6 +95,7 @@ func parseSchedulerConfig(path string) (*schedopt.SchedulerServer, error) {
 		decoder := yaml.NewYAMLOrJSONDecoder(config, 4096)
 		decoder.Decode(&(newScheduler.KubeSchedulerConfiguration))
 	}
+	newScheduler.SchedulerName = "cluster-capacity"
 	return newScheduler, nil
 }
 
@@ -147,6 +148,11 @@ func (s *ClusterCapacityConfig) ParseAPISpec() error {
 
 	if versionedPod.ObjectMeta.Namespace == "" {
 		versionedPod.ObjectMeta.Namespace = "default"
+	}
+
+	// set pod's scheduler name to cluster-capacity
+	if versionedPod.Spec.SchedulerName == "" {
+		versionedPod.Spec.SchedulerName = s.DefaultScheduler.SchedulerName
 	}
 
 	// hardcoded from kube api defaults and validation

--- a/cmd/cluster-capacity/app/server.go
+++ b/cmd/cluster-capacity/app/server.go
@@ -81,18 +81,20 @@ func Validate(opt *options.ClusterCapacityOptions) error {
 
 func Run(opt *options.ClusterCapacityOptions) error {
 	conf := options.NewClusterCapacityConfig(opt)
-	err := conf.ParseAPISpec()
-	if err != nil {
-		return fmt.Errorf("Failed to parse pod spec file: %v ", err)
-	}
 
-	err = conf.SetDefaultScheduler()
+	err := conf.SetDefaultScheduler()
 	if err != nil {
 		return fmt.Errorf("Failed to set default scheduler config: %v ", err)
 	}
+
 	err = conf.ParseAdditionalSchedulerConfigs()
 	if err != nil {
 		return fmt.Errorf("Failed to parse config file: %v ", err)
+	}
+
+	err = conf.ParseAPISpec()
+	if err != nil {
+		return fmt.Errorf("Failed to parse pod spec file: %v ", err)
 	}
 
 	var cfg *restclient.Config


### PR DESCRIPTION
Also if the input pod to cluster capacity
does not specify its scheduler name, set the name to cluster-capacity too.