### PR TITLE
Correct the format of table in api-definitions.md

### DIFF
--- a/doc/api-definitions.md
+++ b/doc/api-definitions.md
@@ -18,6 +18,7 @@
 | Memory | Amount of memory pod requires | false    | string |         |
 
 ##FailReasons
+
 | Name         | Description                                                                         | Required | Schema   | Default |
 |--------------|-------------------------------------------------------------------------------------|----------|----------|---------|
 | FailType     | Reason another instance of pod couldn't be scheduled                                | false    | string   |         |


### PR DESCRIPTION
The table FailReasons format is wrong.
need to insert a empty line below "##FailReasons"